### PR TITLE
--shake (Basic Tree-Shaking), --noAlias (dont append alias), --template (append template), readme lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Add any directories, files, or patterns you don't want to be tracked by version control
 .git
 node_modules
+index.d.ts
 test/**/*.d.ts
 dist
 cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
 # Add any directories, files, or patterns you don't want to be tracked by version control
 .git
 node_modules
-index.d.ts
-test.d.ts
-testNoAlias.d.ts
+test/**/*.d.ts
 dist
 cache
 out

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 node_modules
 index.d.ts
 test.d.ts
+testNoAlias.d.ts
 dist
 cache
 out

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "orta.vscode-jest",
+    "esbenp.prettier-vscode",
+    "ms-vscode.vscode-typescript-tslint-plugin",
+    "wayou.vscode-todo-highlight",
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ npm-dts [options] generate
 |--------|-------|-------------|
 | `--entry [file]` | `-e [file]` | Allows changing main _src_ file from _index.ts_ to something else. It can also be declared as a path, relative to root. |
 | `--force` | `-f` | Ignores non-critical errors and attempts to at least partially generate typings (disabled by default). |
-| `--template` | | Append this template where `{0}` is replaced with the name/path of the entry module. |
+| `--template` | | Append this template where `{main-module}` is replaced with the name/path of the entry module. |
 | `--addAlias` | | Add an alias for the main NPM package file to the generated .d.ts source. (`true`, `false`) (defaults to "true") |
 | `--help` | `-h` | Output usage information. |
 | `--logLevel [level]` | `-L [level]` | Log level (`error`, `warn`, `info`, `verbose`, `debug`) (defaults to "info"). |

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npm-dts [options] generate
 | `--entry [file]` | `-e [file]` | Allows changing main _src_ file from _index.ts_ to something else. It can also be declared as a path, relative to root. |
 | `--force` | `-f` | Ignores non-critical errors and attempts to at least partially generate typings (disabled by default). |
 | `--template` | | Append this template where `{0}` is replaced with the name/path of the entry module. |
-| `--noAlias` | | Don't add an alias for the main NPM package file to the generated .d.ts source. |
+| `--addAlias` | | Add an alias for the main NPM package file to the generated .d.ts source. (`true`, `false`) (defaults to "true") |
 | `--help` | `-h` | Output usage information. |
 | `--logLevel [level]` | `-L [level]` | Log level (`error`, `warn`, `info`, `verbose`, `debug`) (defaults to "info"). |
 | `--output [file]` | `-o [file]` | Overrides recommended output target to a custom one (defaults to "index.d.ts"). |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # npm-dts
 
-_by Vytenis Urbonavičius_
-
 This utility generates single _index.d.ts_ file for whole NPM package.
 
 It allows creating bundled _NPM_ library packages without _TypeScript_ sources and yet still keeping code suggestions wherever these libraries are imported.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ npm-dts [options] generate
 | `--force` | `-f` | Ignores non-critical errors and attempts to at least partially generate typings (disabled by default). |
 | `--help` | `-h` | Output usage information.|
 | `--logLevel [level]` | `-L [level]` | Log level (error, warn, info, verbose, debug) (defaults to "info"). |
-| `--output [file]` | `-o [file]` | Overrides recommended output target to a custom one (defaults to "index.d.ts").    |
+| `--output [file]` | `-o [file]` | Overrides recommended output target to a custom one (defaults to "index.d.ts"). |
+| `--shake` | Basic tree-shaking for modules. (off (default), exportOnly, allImports). Drops modules not referenced by entry. exportOnly only keeps modules which are referenced with the export from ... keyowrd. |
 | `--root [path]` | `-r [path]` | NPM package directory containing package.json (defaults to current working directory).  |
 | `--tmp [path]` | `-t [path]` | Directory for storing temporary information (defaults to OS-specific temporary directory). Note that tool completely deletes this folder once finished. |
 | `--tsc [options]` | `-c [options]` | Passed through additional TSC options (defaults to ""). Note that they are not validated or checked for suitability. When passing through CLI it is recommended to surround arguments in quotes **and start with a space** (work-around for a bug in argument parsing dependency of _npm-dts_). |

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ npm-dts [options] generate
 | `--help` | `-h` | Output usage information. |
 | `--logLevel [level]` | `-L [level]` | Log level (`error`, `warn`, `info`, `verbose`, `debug`) (defaults to "info"). |
 | `--output [file]` | `-o [file]` | Overrides recommended output target to a custom one (defaults to "index.d.ts"). |
-| `--shake` | `-s` | Basic tree-shaking for modules. (`off` (default), `exportOnly`, `allImports`). `allImports` drops modules not referenced by the entry module. `exportOnly` only keeps modules which are referenced with the `export from ...` keyword. |
+| `--shake` | `-s` | Basic tree-shaking for modules. (`off` (default), `exportOnly`, `referencedOnly`). `referencedOnly` drops modules not referenced by the entry module. `exportOnly` only keeps modules which are referenced with the `export from ...` keyword. |
 | `--root [path]` | `-r [path]` | NPM package directory containing package.json (defaults to current working directory). |
 | `--tmp [path]` | `-t [path]` | Directory for storing temporary information (defaults to OS-specific temporary directory). Note that tool completely deletes this folder once finished. |
 | `--tsc [options]` | `-c [options]` | Passed through additional TSC options (defaults to ""). Note that they are not validated or checked for suitability. When passing through CLI it is recommended to surround arguments in quotes **and start with a space** (work-around for a bug in argument parsing dependency of _npm-dts_). |

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ npm-dts [options] generate
 | `--entry [file]` | `-e [file]` | Allows changing main _src_ file from _index.ts_ to something else. It can also be declared as a path, relative to root. |
 | `--force` | `-f` | Ignores non-critical errors and attempts to at least partially generate typings (disabled by default). |
 | `--help` | `-h` | Output usage information.|
+| `--template` | | Append this template where {0} is replaced with the name/path of the entry module. |
 | `--logLevel [level]` | `-L [level]` | Log level (error, warn, info, verbose, debug) (defaults to "info"). |
 | `--output [file]` | `-o [file]` | Overrides recommended output target to a custom one (defaults to "index.d.ts").    |
 | `--root [path]` | `-r [path]` | NPM package directory containing package.json (defaults to current working directory).  |

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ npm-dts [options] generate
 | `--help` | `-h` | Output usage information. |
 | `--logLevel [level]` | `-L [level]` | Log level (`error`, `warn`, `info`, `verbose`, `debug`) (defaults to "info"). |
 | `--output [file]` | `-o [file]` | Overrides recommended output target to a custom one (defaults to "index.d.ts"). |
-| `--shake` | `-s` | Basic tree-shaking for modules. (`off` (default), `exportOnly`, `referencedOnly`). `referencedOnly` drops modules not referenced by the entry module. `exportOnly` only keeps modules which are referenced with the `export from ...` keyword. |
+| `--shake` | `-s` | Basic tree-shaking for modules. (`off` (default), `exportedOnly`, `referencedOnly`). `referencedOnly` drops modules not referenced by the entry module. `exportedOnly` only keeps modules which are referenced with the `export from ...` keyword. |
 | `--root [path]` | `-r [path]` | NPM package directory containing package.json (defaults to current working directory). |
 | `--tmp [path]` | `-t [path]` | Directory for storing temporary information (defaults to OS-specific temporary directory). Note that tool completely deletes this folder once finished. |
 | `--tsc [options]` | `-c [options]` | Passed through additional TSC options (defaults to ""). Note that they are not validated or checked for suitability. When passing through CLI it is recommended to surround arguments in quotes **and start with a space** (work-around for a bug in argument parsing dependency of _npm-dts_). |

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ npm-dts [options] generate
 | `--help` | `-h` | Output usage information. |
 | `--logLevel [level]` | `-L [level]` | Log level (`error`, `warn`, `info`, `verbose`, `debug`) (defaults to "info"). |
 | `--output [file]` | `-o [file]` | Overrides recommended output target to a custom one (defaults to "index.d.ts"). |
-| `--shake` | `-s` | Basic tree-shaking for modules. (`off` (default), `exportedOnly`, `referencedOnly`). `referencedOnly` drops modules not referenced by the entry module. `exportedOnly` only keeps modules which are referenced with the `export from ...` keyword. |
+| `--shake` | `-s` | Basic tree-shaking for modules. (`off` (default), `referencedOnly`). `referencedOnly` drops modules not referenced by the entry module. |
 | `--root [path]` | `-r [path]` | NPM package directory containing package.json (defaults to current working directory). |
 | `--tmp [path]` | `-t [path]` | Directory for storing temporary information (defaults to OS-specific temporary directory). Note that tool completely deletes this folder once finished. |
 | `--tsc [options]` | `-c [options]` | Passed through additional TSC options (defaults to ""). Note that they are not validated or checked for suitability. When passing through CLI it is recommended to surround arguments in quotes **and start with a space** (work-around for a bug in argument parsing dependency of _npm-dts_). |

--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ npm-dts [options] generate
 |--------|-------|-------------|
 | `--entry [file]` | `-e [file]` | Allows changing main _src_ file from _index.ts_ to something else. It can also be declared as a path, relative to root. |
 | `--force` | `-f` | Ignores non-critical errors and attempts to at least partially generate typings (disabled by default). |
-| `--template` | | Append this template where {0} is replaced with the name/path of the entry module. |
+| `--template` | | Append this template where `{0}` is replaced with the name/path of the entry module. |
 | `--noAlias` | | Don't add an alias for the main NPM package file to the generated .d.ts source. |
 | `--help` | `-h` | Output usage information. |
-| `--logLevel [level]` | `-L [level]` | Log level (error, warn, info, verbose, debug) (defaults to "info"). |
+| `--logLevel [level]` | `-L [level]` | Log level (`error`, `warn`, `info`, `verbose`, `debug`) (defaults to "info"). |
 | `--output [file]` | `-o [file]` | Overrides recommended output target to a custom one (defaults to "index.d.ts"). |
-| `--shake` | Basic tree-shaking for modules. (off (default), exportOnly, allImports). Drops modules not referenced by entry. exportOnly only keeps modules which are referenced with the export from ... keyowrd. |
+| `--shake` | `-s` | Basic tree-shaking for modules. (`off` (default), `exportOnly`, `allImports`). `allImports` drops modules not referenced by the entry module. `exportOnly` only keeps modules which are referenced with the `export from ...` keyword. |
 | `--root [path]` | `-r [path]` | NPM package directory containing package.json (defaults to current working directory). |
 | `--tmp [path]` | `-t [path]` | Directory for storing temporary information (defaults to OS-specific temporary directory). Note that tool completely deletes this folder once finished. |
 | `--tsc [options]` | `-c [options]` | Passed through additional TSC options (defaults to ""). Note that they are not validated or checked for suitability. When passing through CLI it is recommended to surround arguments in quotes **and start with a space** (work-around for a bug in argument parsing dependency of _npm-dts_). |

--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ npm-dts [options] generate
 |--------|-------|-------------|
 | `--entry [file]` | `-e [file]` | Allows changing main _src_ file from _index.ts_ to something else. It can also be declared as a path, relative to root. |
 | `--force` | `-f` | Ignores non-critical errors and attempts to at least partially generate typings (disabled by default). |
-| `--help` | `-h` | Output usage information.|
 | `--template` | | Append this template where {0} is replaced with the name/path of the entry module. |
+| `--help` | `-h` | Output usage information. |
 | `--logLevel [level]` | `-L [level]` | Log level (error, warn, info, verbose, debug) (defaults to "info"). |
-| `--output [file]` | `-o [file]` | Overrides recommended output target to a custom one (defaults to "index.d.ts").    |
-| `--root [path]` | `-r [path]` | NPM package directory containing package.json (defaults to current working directory).  |
+| `--output [file]` | `-o [file]` | Overrides recommended output target to a custom one (defaults to "index.d.ts"). |
+| `--root [path]` | `-r [path]` | NPM package directory containing package.json (defaults to current working directory). |
 | `--tmp [path]` | `-t [path]` | Directory for storing temporary information (defaults to OS-specific temporary directory). Note that tool completely deletes this folder once finished. |
 | `--tsc [options]` | `-c [options]` | Passed through additional TSC options (defaults to ""). Note that they are not validated or checked for suitability. When passing through CLI it is recommended to surround arguments in quotes **and start with a space** (work-around for a bug in argument parsing dependency of _npm-dts_). |
 | `--version` | `-v` | Output the version number. |

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ npm-dts [options] generate
 |--------|-------|-------------|
 | `--entry [file]` | `-e [file]` | Allows changing main _src_ file from _index.ts_ to something else. It can also be declared as a path, relative to root. |
 | `--force` | `-f` | Ignores non-critical errors and attempts to at least partially generate typings (disabled by default). |
-| `--help` | `-h` | Output usage information.|
+| `--help` | `-h` | Output usage information. |
 | `--logLevel [level]` | `-L [level]` | Log level (error, warn, info, verbose, debug) (defaults to "info"). |
-| `--output [file]` | `-o [file]` | Overrides recommended output target to a custom one (defaults to "index.d.ts").    |
-| `--root [path]` | `-r [path]` | NPM package directory containing package.json (defaults to current working directory).  |
+| `--output [file]` | `-o [file]` | Overrides recommended output target to a custom one (defaults to "index.d.ts"). |
+| `--root [path]` | `-r [path]` | NPM package directory containing package.json (defaults to current working directory). |
 | `--tmp [path]` | `-t [path]` | Directory for storing temporary information (defaults to OS-specific temporary directory). Note that tool completely deletes this folder once finished. |
 | `--tsc [options]` | `-c [options]` | Passed through additional TSC options (defaults to ""). Note that they are not validated or checked for suitability. When passing through CLI it is recommended to surround arguments in quotes **and start with a space** (work-around for a bug in argument parsing dependency of _npm-dts_). |
 | `--version` | `-v` | Output the version number. |

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ _TypeScript_ picks up _index.d.ts_ automatically.
 
 Local:
 
-```
+```cmd
 npm install --save-dev npm-dts
 ```
 
 Global:
 
-```
+```cmd
 npm install -g npm-dts
 ```
 
@@ -32,50 +32,44 @@ Please make sure that target project has _"typescript"_ installed in _node_modul
 
 To see full _CLI_ help - run without arguments:
 
-```
+```cmd
 npm-dts
 ```
 
 Typical usage (using global install):
 
-```
+```cmd
 cd /your/project
 npm-dts generate
 ```
 
-<br />
-
 ### Supported options
 
-```
+```cmd
 npm-dts [options] generate
 ```
 
-| Option&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Alias&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Description                                                                                                                                                                                      |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| <code>--entry [file]</code>                                                                                                                                                                                                                                        | <code>-e [file]</code>                                                                                                                                                        | Allows changing main _src_ file from _index.ts_ to something else. It can also be declared as a path, relative to root.                                                                          |
-| <code>--force</code>                                                                                                                                                                                                                                               | <code>-f</code>                                                                                                                                                               | Ignores non-critical errors and attempts to at least partially generate typings (disabled by default).                                                                                           |
-| <code>--help</code>                                                                                                                                                                                                                                                | <code>-h</code>                                                                                                                                                               | Output usage information.                                                                                                                                                                        |
-| <code>--logLevel [level]</code>                                                                                                                                                                                                                                    | <code>-L [level]</code>                                                                                                                                                       | Log level (error, warn, info, verbose, debug) (defaults to "info").                                                                                                                              |
-| <code>--output [file]</code>                                                                                                                                                                                                                                       | <code>-o [file]</code>                                                                                                                                                        | Overrides recommended output target to a custom one (defaults to "index.d.ts").                                                                                                                  |
-| <code>--root [path]</code>                                                                                                                                                                                                                                         | <code>-r [path]</code>                                                                                                                                                        | NPM package directory containing package.json (defaults to current working directory).                                                                                                           |
-| <code>--tmp [path]</code>                                                                                                                                                                                                                                          | <code>-t [path]</code>                                                                                                                                                        | Directory for storing temporary information (defaults to OS-specific temporary directory). Note that tool completely deletes this folder once finished.                                          |
-| <code>--tsc [options]</code>                                                                                                                                                                                                                                       | <code>-c [options]</code>                                                                                                                                                     | Passed through additional TSC options (defaults to ""). Note that they are not validated or checked for suitability. When passing through CLI it is recommended to surround arguments in quotes **and start with a space** (work-around for a bug in argument parsing dependency of _npm-dts_). |
-| <code>--version</code>                                                                                                                                                                                                                                             | <code>-v</code>                                                                                                                                                               | Output the version number.                                                                                                                                                                       |
-
-<br>
+| Option | Alias | Description |
+|--------|-------|-------------|
+| `--entry [file]` | `-e [file]` | Allows changing main _src_ file from _index.ts_ to something else. It can also be declared as a path, relative to root. |
+| `--force` | `-f` | Ignores non-critical errors and attempts to at least partially generate typings (disabled by default). |
+| `--help` | `-h` | Output usage information.|
+| `--logLevel [level]` | `-L [level]` | Log level (error, warn, info, verbose, debug) (defaults to "info"). |
+| `--output [file]` | `-o [file]` | Overrides recommended output target to a custom one (defaults to "index.d.ts").    |
+| `--root [path]` | `-r [path]` | NPM package directory containing package.json (defaults to current working directory).  |
+| `--tmp [path]` | `-t [path]` | Directory for storing temporary information (defaults to OS-specific temporary directory). Note that tool completely deletes this folder once finished. |
+| `--tsc [options]` | `-c [options]` | Passed through additional TSC options (defaults to ""). Note that they are not validated or checked for suitability. When passing through CLI it is recommended to surround arguments in quotes **and start with a space** (work-around for a bug in argument parsing dependency of _npm-dts_). |
+| `--version` | `-v` | Output the version number. |
 
 ## Integration using _WebPack_
 
 You would want to use [**"npm-dts-webpack-plugin"**](https://www.npmjs.com/package/npm-dts-webpack-plugin) package instead.
 
-<br />
-
 ## Integration into _NPM_ scripts
 
 Example of how you could run generation of _index.d.ts_ automatically before every publish.
 
-```
+```json
 {
   // ......
   "scripts": {
@@ -87,8 +81,6 @@ Example of how you could run generation of _index.d.ts_ automatically before eve
 ```
 
 Another possible option would be to execute "npm run dts" as part of bundling task.
-
-<br />
 
 ## Integration into custom solution
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ npm-dts [options] generate
 |--------|-------|-------------|
 | `--entry [file]` | `-e [file]` | Allows changing main _src_ file from _index.ts_ to something else. It can also be declared as a path, relative to root. |
 | `--force` | `-f` | Ignores non-critical errors and attempts to at least partially generate typings (disabled by default). |
-| `--template` | | Append this template where `{main-module}` is replaced with the name/path of the entry module. |
-| `--addAlias` | | Add an alias for the main NPM package file to the generated .d.ts source. (`true`, `false`) (defaults to "true") |
+| `--customAlias` | `-a` | Instead of an alias, use the given template, where `{main-module}` is replaced with the name/path of the entry module and `{package-name}` is replaced with the name of the package. |
 | `--help` | `-h` | Output usage information. |
 | `--logLevel [level]` | `-L [level]` | Log level (`error`, `warn`, `info`, `verbose`, `debug`) (defaults to "info"). |
 | `--output [file]` | `-o [file]` | Overrides recommended output target to a custom one (defaults to "index.d.ts"). |

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ npm-dts [options] generate
 |--------|-------|-------------|
 | `--entry [file]` | `-e [file]` | Allows changing main _src_ file from _index.ts_ to something else. It can also be declared as a path, relative to root. |
 | `--force` | `-f` | Ignores non-critical errors and attempts to at least partially generate typings (disabled by default). |
+| `--noAlias` | | Don't add an alias for the main NPM package file to the generated .d.ts source. |
 | `--help` | `-h` | Output usage information.|
 | `--logLevel [level]` | `-L [level]` | Log level (error, warn, info, verbose, debug) (defaults to "info"). |
 | `--output [file]` | `-o [file]` | Overrides recommended output target to a custom one (defaults to "index.d.ts").    |

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -74,7 +74,7 @@ export enum EShakeOptions {
   exportOnly = 'exportOnly',
 
   /** only keep modules that are referenced by the entry module */
-  allImports = 'allImports',
+  referencedOnly = 'referencedOnly',
 }
 
 /**
@@ -227,7 +227,7 @@ export class Cli {
         )
         .option(
           ['s', 'shake'],
-          'Basic tree-shaking for modules. (off (default), exportOnly, allImports). allImports drops modules not referenced by entry. exportOnly only keeps modules which are referenced with the export from ... keyword.',
+          'Basic tree-shaking for modules. (off (default), exportOnly, referencedOnly). referencedOnly drops modules not referenced by entry. exportOnly only keeps modules which are referenced with the export from ... keyword.',
           this.args.shake,
         )
         .option(

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -71,7 +71,7 @@ export enum EShakeOptions {
   off = 'off',
 
   /** remove everything but exported modules */
-  exportOnly = 'exportOnly',
+  exportedOnly = 'exportedOnly',
 
   /** only keep modules that are referenced by the entry module */
   referencedOnly = 'referencedOnly',
@@ -227,7 +227,7 @@ export class Cli {
         )
         .option(
           ['s', 'shake'],
-          'Basic tree-shaking for modules. (off (default), exportOnly, referencedOnly). referencedOnly drops modules not referenced by entry. exportOnly only keeps modules which are referenced with the export from ... keyword.',
+          'Basic tree-shaking for modules. (off (default), exportedOnly, referencedOnly). referencedOnly drops modules not referenced by entry. exportedOnly only keeps modules which are referenced with the export from ... keyword.',
           this.args.shake,
         )
         .option(

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -1,6 +1,6 @@
 import * as args from 'args'
 import * as path from 'path'
-import { ELogLevel } from './log'
+import {ELogLevel} from './log'
 
 /**
  * CLI argument names
@@ -65,6 +65,18 @@ export enum ECliArgument {
   shake = 'shake',
 }
 
+/** options for the --shake argument */
+export enum EShakeOptions {
+  /** dont shake (default) */
+  off = 'off',
+
+  /** remove everything but exported modules */
+  exportOnly = 'exportOnly',
+
+  /** only keep modules that are referenced by the entry module */
+  allImports = 'allImports',
+}
+
 /**
  * Configuration structure for generating an aggregated dts file
  */
@@ -112,7 +124,7 @@ export interface INpmDtsArgs {
   /**
    * Basic tree-shaking on module level
    */
-  shake?: 'off' | 'exportOnly' | 'allImports'
+  shake?: EShakeOptions
 
   /**
    * Output file path (relative to root)
@@ -157,7 +169,7 @@ export class Cli {
     logLevel: ELogLevel.info,
     noAlias: false,
     force: false,
-    shake: 'off',
+    shake: EShakeOptions.off,
     output: 'index.d.ts',
     template: undefined,
     testMode: false,
@@ -214,8 +226,8 @@ export class Cli {
           this.args.force,
         )
         .option(
-          'shake',
-          'Basic tree-shaking for modules. (off (default), exportOnly, allImports). Drops modules not referenced by entry. exportOnly only keeps modules which are referenced with the export from ... keyowrd.',
+          ['s', 'shake'],
+          'Basic tree-shaking for modules. (off (default), exportOnly, allImports). allImports drops modules not referenced by entry. exportOnly only keeps modules which are referenced with the export from ... keyword.',
           this.args.shake,
         )
         .option(
@@ -233,7 +245,7 @@ export class Cli {
           'Configures npm-dts for self-test',
           this.args.testMode,
         )
-        .command('generate', 'Start generation', (name: any, sub: any, options: any) => {
+        .command('generate', 'Start generation', (name, sub, options) => {
           this.launched = true
           this.storeArguments(options)
         })

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -1,6 +1,6 @@
 import * as args from 'args'
 import * as path from 'path'
-import {ELogLevel} from './log'
+import { ELogLevel } from './log'
 
 /**
  * CLI argument names
@@ -47,6 +47,11 @@ export enum ECliArgument {
    * Flag which forces attempting generation at least partially despite errors
    */
   force = 'force',
+
+  /**
+   * Basic tree-shaking on module level
+   */
+  shake = 'shake',
 }
 
 /**
@@ -89,6 +94,11 @@ export interface INpmDtsArgs {
   force?: boolean
 
   /**
+   * Basic tree-shaking on module level
+   */
+  shake?: 'off' | 'exportOnly' | 'allImports'
+
+  /**
    * Output file path (relative to root)
    */
   output?: string
@@ -125,6 +135,7 @@ export class Cli {
     tsc: '',
     logLevel: ELogLevel.info,
     force: false,
+    shake: 'off',
     output: 'index.d.ts',
     testMode: false,
   }
@@ -175,6 +186,11 @@ export class Cli {
           this.args.force,
         )
         .option(
+          'shake',
+          'Basic tree-shaking for modules. (off (default), exportOnly, allImports). Drops modules not referenced by entry. exportOnly only keeps modules which are referenced with the export from ... keyowrd.',
+          this.args.shake,
+        )
+        .option(
           ['o', 'output'],
           'Overrides recommended output target to a custom one',
           this.args.output,
@@ -184,7 +200,7 @@ export class Cli {
           'Configures npm-dts for self-test',
           this.args.testMode,
         )
-        .command('generate', 'Start generation', (name, sub, options) => {
+        .command('generate', 'Start generation', (name: any, sub: any, options: any) => {
           this.launched = true
           this.storeArguments(options)
         })

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -64,9 +64,6 @@ export enum EShakeOptions {
   /** dont shake (default) */
   off = 'off',
 
-  /** remove everything but exported modules */
-  exportedOnly = 'exportedOnly',
-
   /** only keep modules that are referenced by the entry module */
   referencedOnly = 'referencedOnly',
 }
@@ -223,7 +220,7 @@ export class Cli {
         )
         .option(
           ['s', 'shake'],
-          'Basic tree-shaking for modules. (off (default), exportedOnly, referencedOnly). referencedOnly drops modules not referenced by entry. exportedOnly only keeps modules which are referenced with the export from ... keyword.',
+          'Basic tree-shaking for modules. (off (default), referencedOnly). referencedOnly drops modules not referenced by the entry module.',
           this.args.shake,
         )
         .option(

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -49,10 +49,10 @@ export enum ECliArgument {
   testMode = 'testMode',
 
   /**
-   * Flag which forces not to add an alias for the main NPM
+   * Flag which enables/disable adding an alias for the main NPM
    * package file to the generated .d.ts source
    */
-  noAlias = 'noAlias',
+  addAlias = 'addAlias',
 
   /**
    * Flag which forces attempting generation at least partially despite errors
@@ -112,9 +112,9 @@ export interface INpmDtsArgs {
   logLevel?: ELogLevel
 
   /**
-   * Don't add an alias for the main NPM package file to the generated .d.ts source
+   * Add an alias for the main NPM package file to the generated .d.ts source
    */
-  noAlias?: boolean
+  addAlias?: 'true' | 'false'
 
   /**
    * Attempts to at least partially generate typings ignoring non-critical errors
@@ -167,7 +167,7 @@ export class Cli {
     tmp: '<TEMP>',
     tsc: '',
     logLevel: ELogLevel.info,
-    noAlias: false,
+    addAlias: 'true',
     force: false,
     shake: EShakeOptions.off,
     output: 'index.d.ts',
@@ -216,9 +216,9 @@ export class Cli {
           this.args.logLevel,
         )
         .option(
-          'noAlias',
-          'Don\'t add an alias for the main NPM package file to the generated .d.ts source',
-          this.args.noAlias,
+          'addAlias',
+          'Add an alias for the main NPM package file to the generated .d.ts source (true, false) - default true',
+          this.args.addAlias,
         )
         .option(
           ['f', 'force'],

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -1,6 +1,6 @@
 import * as args from 'args'
 import * as path from 'path'
-import {ELogLevel} from './log'
+import { ELogLevel } from './log'
 
 /**
  * CLI argument names
@@ -35,6 +35,11 @@ export enum ECliArgument {
    * Output file path (relative to root)
    */
   output = 'output',
+
+  /**
+   * Append this template where {0} is replaced with the name/path of the entry module.
+   */
+  template = 'template',
 
   /**
    * Flag which forces using own TSC as opposed to target TSC
@@ -94,6 +99,11 @@ export interface INpmDtsArgs {
   output?: string
 
   /**
+   * Append this template where {0} is replaced with the name/path of the entry module.
+   */
+  template?: string
+
+  /**
    * Flag which forces using own TSC as opposed to target TSC
    * This should only be used for testing npm-dts itself
    * This is because it generates incorrect module names
@@ -126,6 +136,7 @@ export class Cli {
     logLevel: ELogLevel.info,
     force: false,
     output: 'index.d.ts',
+    template: undefined,
     testMode: false,
   }
 
@@ -178,6 +189,11 @@ export class Cli {
           ['o', 'output'],
           'Overrides recommended output target to a custom one',
           this.args.output,
+        )
+        .option(
+          'template',
+          'Append this template where {0} is replaced with the name/path of the entry module.',
+          this.args.template,
         )
         .option(
           ['m', 'testMode'],

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -37,7 +37,7 @@ export enum ECliArgument {
   output = 'output',
 
   /**
-   * Append this template where {0} is replaced with the name/path of the entry module.
+   * Append this template where {main-module} is replaced with the name/path of the entry module.
    */
   template = 'template',
 
@@ -132,7 +132,7 @@ export interface INpmDtsArgs {
   output?: string
 
   /**
-   * Append this template where {0} is replaced with the name/path of the entry module.
+   * Append this template where {main-module} is replaced with the name/path of the entry module.
    */
   template?: string
 
@@ -237,7 +237,7 @@ export class Cli {
         )
         .option(
           'template',
-          'Append this template where {0} is replaced with the name/path of the entry module.',
+          'Append this template where {main-module} is replaced with the name/path of the entry module.',
           this.args.template,
         )
         .option(

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -1,6 +1,6 @@
 import * as args from 'args'
 import * as path from 'path'
-import {ELogLevel} from './log'
+import { ELogLevel } from './log'
 
 /**
  * CLI argument names
@@ -44,6 +44,12 @@ export enum ECliArgument {
   testMode = 'testMode',
 
   /**
+   * Flag which forces not to add an alias for the main NPM
+   * package file to the generated .d.ts source
+   */
+  noAlias = 'noAlias',
+
+  /**
    * Flag which forces attempting generation at least partially despite errors
    */
   force = 'force',
@@ -82,6 +88,11 @@ export interface INpmDtsArgs {
    * Selected logging level
    */
   logLevel?: ELogLevel
+
+  /**
+   * Don't add an alias for the main NPM package file to the generated .d.ts source
+   */
+  noAlias?: boolean
 
   /**
    * Attempts to at least partially generate typings ignoring non-critical errors
@@ -124,6 +135,7 @@ export class Cli {
     tmp: '<TEMP>',
     tsc: '',
     logLevel: ELogLevel.info,
+    noAlias: false,
     force: false,
     output: 'index.d.ts',
     testMode: false,
@@ -168,6 +180,11 @@ export class Cli {
           ['L', 'logLevel'],
           'Log level (error, warn, info, verbose, debug)',
           this.args.logLevel,
+        )
+        .option(
+          'noAlias',
+          'Don\'t add an alias for the main NPM package file to the generated .d.ts source',
+          this.args.noAlias,
         )
         .option(
           ['f', 'force'],

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -585,12 +585,12 @@ export class Generator extends Cli {
     shakenTypings: Set<string>,
     filter: 'exportOnly' | 'allImports',
   ): void {
-    shakenTypings.add(moduleName)
     const current = typings[moduleName]
     if (current === undefined) {
       warn(`no typings for "${moduleName}"`)
       return
     }
+    shakenTypings.add(moduleName)
     const lines = this.sourceLines(current)
     const refs =
       filter === 'allImports'
@@ -599,6 +599,7 @@ export class Generator extends Cli {
     verbose(`"${moduleName}" references ${JSON.stringify(refs)}`)
 
     for (const ref of refs) {
+      if (shakenTypings.has(ref)) continue
       this.findDependencies(typings, ref, shakenTypings, filter)
     }
   }

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -5,7 +5,7 @@ import * as npmRun from 'npm-run'
 import {join, relative, resolve, dirname} from 'path'
 import * as rm from 'rimraf'
 import * as tmp from 'tmp'
-import {Cli, ECliArgument, INpmDtsArgs} from './cli'
+import {Cli, ECliArgument, EShakeOptions, INpmDtsArgs} from './cli'
 import {debug, ELogLevel, error, info, init, verbose, warn} from './log'
 import * as fs from 'fs'
 
@@ -243,17 +243,10 @@ export class Generator extends Cli {
   /**
    * Checks how and if tree-shaking should be applied
    */
-  private getShake(): 'off' | 'exportOnly' | 'allImports' {
-    const shake = this.getArgument(ECliArgument.shake) as
-      | undefined
-      | 'off'
-      | 'exportOnly'
-      | 'allImports'
-    if (shake === undefined) return 'off'
-    if (shake === 'exportOnly' || shake === 'allImports' || shake === 'off')
-      return shake
-    error(`Unknown value for shake "${shake}"`)
-    if (shake === undefined) return 'off'
+  private getShake(): EShakeOptions {
+    const shake = this.getArgument(ECliArgument.shake) as EShakeOptions
+    if (EShakeOptions[shake]) return shake
+    return EShakeOptions.off
   }
 
   /**

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -696,8 +696,8 @@ export class Generator extends Cli {
     const mainModule = this.convertPathToModule(
       resolve(this.getRoot(), entry),
       {
-      rootType: IBasePathType.root,
-      noExistenceCheck: true,
+        rootType: IBasePathType.root,
+        noExistenceCheck: true,
       },
     )
     return mainModule
@@ -761,7 +761,7 @@ export class Generator extends Cli {
 const shakeStrategies = {
   [EShakeOptions.off]: (lines: string[]) => lines,
 
-  [EShakeOptions.allImports]: (lines: string[]) => {
+  [EShakeOptions.referencedOnly]: (lines: string[]) => {
     const refs = [
       ...lines.map(line => line.match(REG_STATIC_IMPORT)),
       ...lines.map(line => line.match(REG_INLINE_IMPORT)),

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -769,7 +769,7 @@ const shakeStrategies = {
     return refs.filter(match => match !== null).map(match => match[2])
   },
 
-  [EShakeOptions.exportOnly]: (lines: string[]) => {
+  [EShakeOptions.exportedOnly]: (lines: string[]) => {
     const exports = /export .*? from ['"]([^'"]+)['"]/
     const refs = lines.map(l => l.match(exports))
     return refs.filter(m => m !== null).map(m => m[1])

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -1,12 +1,12 @@
-import {readdirSync, statSync, writeFileSync} from 'fs'
-import {readFileSync} from 'fs'
+import { readdirSync, statSync, writeFileSync } from 'fs'
+import { readFileSync } from 'fs'
 import * as mkdir from 'mkdirp'
 import * as npmRun from 'npm-run'
-import {join, relative, resolve, dirname} from 'path'
+import { join, relative, resolve, dirname } from 'path'
 import * as rm from 'rimraf'
 import * as tmp from 'tmp'
-import {Cli, ECliArgument, INpmDtsArgs} from './cli'
-import {debug, ELogLevel, error, info, init, verbose, warn} from './log'
+import { Cli, ECliArgument, INpmDtsArgs } from './cli'
+import { debug, ELogLevel, error, info, init, verbose, warn } from './log'
 import * as fs from 'fs'
 
 const MKDIR_RETRIES = 5
@@ -218,6 +218,14 @@ export class Generator extends Cli {
   }
 
   /**
+   * Checks if an alias for the main NPM package file should be
+   * added to the generated .d.ts source
+   */
+  private noAlias(): boolean {
+    return this.getArgument(ECliArgument.noAlias) as boolean
+  }
+
+  /**
    * Checks if script is forced to attempt generation despite errors
    */
   private useForce(): boolean {
@@ -398,7 +406,7 @@ export class Generator extends Cli {
 
     try {
       this.packageInfo = JSON.parse(
-        readFileSync(packageJsonPath, {encoding: 'utf8'}),
+        readFileSync(packageJsonPath, { encoding: 'utf8' }),
       )
     } catch (e) {
       error(`Failed to read package.json at "'${packageJsonPath}'"`)
@@ -469,7 +477,7 @@ export class Generator extends Cli {
       const moduleName = this.convertPathToModule(file)
 
       try {
-        result[moduleName] = readFileSync(file, {encoding: 'utf8'})
+        result[moduleName] = readFileSync(file, { encoding: 'utf8' })
       } catch (e) {
         error(`Could not load declaration file '${file}'!`)
         this.showDebugError(e)
@@ -579,10 +587,12 @@ export class Generator extends Cli {
   }
 
   /**
-   * Adds alias for main NPM package file to generated .d.ts source
+   * Adds an  alias for the main NPM package file to the
+   * generated .d.ts source
    * @param source generated .d.ts declaration source so far
    */
   private addAlias(source: string) {
+    if (this.noAlias()) return source;
     verbose('Adding alias for main file of the package...')
 
     const packageDetails = this.getPackageDetails()
@@ -634,7 +644,7 @@ export class Generator extends Cli {
     verbose(`Storing typings into ${output} file...`)
 
     try {
-      writeFileSync(file, source, {encoding: 'utf8'})
+      writeFileSync(file, source, { encoding: 'utf8' })
     } catch (e) {
       error(`Failed to create ${output}!`)
       this.showDebugError(e)

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -587,6 +587,10 @@ export class Generator extends Cli {
   ): void {
     shakenTypings.add(moduleName)
     const current = typings[moduleName]
+    if (current === undefined) {
+      warn(`no typings for "${moduleName}"`)
+      return
+    }
     const lines = this.sourceLines(current)
     const refs =
       filter === 'allImports'

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -1,12 +1,12 @@
-import { readdirSync, statSync, writeFileSync } from 'fs'
-import { readFileSync } from 'fs'
+import {readdirSync, statSync, writeFileSync} from 'fs'
+import {readFileSync} from 'fs'
 import * as mkdir from 'mkdirp'
 import * as npmRun from 'npm-run'
-import { join, relative, resolve, dirname } from 'path'
+import {join, relative, resolve, dirname} from 'path'
 import * as rm from 'rimraf'
 import * as tmp from 'tmp'
-import { Cli, ECliArgument, INpmDtsArgs } from './cli'
-import { debug, ELogLevel, error, info, init, verbose, warn } from './log'
+import {Cli, ECliArgument, INpmDtsArgs} from './cli'
+import {debug, ELogLevel, error, info, init, verbose, warn} from './log'
 import * as fs from 'fs'
 
 const MKDIR_RETRIES = 5
@@ -244,9 +244,14 @@ export class Generator extends Cli {
    * Checks how and if tree-shaking should be applied
    */
   private getShake(): 'off' | 'exportOnly' | 'allImports' {
-    const shake = this.getArgument(ECliArgument.shake) as undefined | 'off' | 'exportOnly' | 'allImports'
+    const shake = this.getArgument(ECliArgument.shake) as
+      | undefined
+      | 'off'
+      | 'exportOnly'
+      | 'allImports'
     if (shake === undefined) return 'off'
-    if (shake === 'exportOnly' || shake === 'allImports' || shake === 'off') return shake
+    if (shake === 'exportOnly' || shake === 'allImports' || shake === 'off')
+      return shake
     error(`Unknown value for shake "${shake}"`)
     if (shake === undefined) return 'off'
   }
@@ -425,7 +430,7 @@ export class Generator extends Cli {
 
     try {
       this.packageInfo = JSON.parse(
-        readFileSync(packageJsonPath, { encoding: 'utf8' }),
+        readFileSync(packageJsonPath, {encoding: 'utf8'}),
       )
     } catch (e) {
       error(`Failed to read package.json at "'${packageJsonPath}'"`)
@@ -496,7 +501,7 @@ export class Generator extends Cli {
       const moduleName = this.convertPathToModule(file)
 
       try {
-        result[moduleName] = readFileSync(file, { encoding: 'utf8' })
+        result[moduleName] = readFileSync(file, {encoding: 'utf8'})
       } catch (e) {
         error(`Could not load declaration file '${file}'!`)
         this.showDebugError(e)
@@ -578,12 +583,15 @@ export class Generator extends Cli {
     typings: IDeclarationMap,
     moduleName: string,
     shakenTypings: Set<string>,
-    filter: 'exportOnly' | 'allImports'
+    filter: 'exportOnly' | 'allImports',
   ): void {
     shakenTypings.add(moduleName)
     const current = typings[moduleName]
     const lines = this.sourceLines(current)
-    const refs = filter === 'allImports' ? this.findAllImportedRefs(lines) : this.findExportedRefsOnly(lines)
+    const refs =
+      filter === 'allImports'
+        ? this.findAllImportedRefs(lines)
+        : this.findExportedRefsOnly(lines)
     verbose(`"${moduleName}" references ${JSON.stringify(refs)}`)
 
     for (const ref of refs) {
@@ -602,7 +610,7 @@ export class Generator extends Cli {
     const inlineImport = /(import\(['"])([^'"]+)(['"]\))/
     const refs = [
       ...lines.map(l => l.match(staticImports)),
-      ...lines.map(l => l.match(inlineImport))
+      ...lines.map(l => l.match(inlineImport)),
     ]
     return refs.filter(m => m !== null).map(m => m[1])
   }
@@ -631,7 +639,9 @@ export class Generator extends Cli {
       verbose(`Shaking typeings using the ${shake} strategy.`)
       const referenced = new Set<string>()
       this.findDependencies(typings, mainFile, referenced, shake)
-      const shakenTypings = Object.fromEntries(Array.from(referenced).map(ref => [ref, typings[ref]]))
+      const shakenTypings = Object.fromEntries(
+        Array.from(referenced).map(ref => [ref, typings[ref]]),
+      )
       typings = shakenTypings
     }
 
@@ -750,7 +760,7 @@ export class Generator extends Cli {
     verbose(`Storing typings into ${output} file...`)
 
     try {
-      writeFileSync(file, source, { encoding: 'utf8' })
+      writeFileSync(file, source, {encoding: 'utf8'})
     } catch (e) {
       error(`Failed to create ${output}!`)
       this.showDebugError(e)

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -173,8 +173,8 @@ export class Generator extends Cli {
   private async _generate() {
     await this.generateTypings()
     let source = await this.combineTypings()
-    source = this.addAlias(source)
-    source = this.addTemplate(source)
+    if (this.addAlias()) source = this.appendAlias(source)
+    if (this.addTemplate()) source = this.appendTemplate(source)
     await this.storeResult(source)
   }
 
@@ -218,6 +218,10 @@ export class Generator extends Cli {
     return this.getArgument(ECliArgument.template) as string | undefined
   }
 
+  private addTemplate(): boolean {
+    return this.getArgument(ECliArgument.template) !== undefined
+  }
+
   /**
    * Checks if script is forced to use its built-in TSC
    */
@@ -229,8 +233,8 @@ export class Generator extends Cli {
    * Checks if an alias for the main NPM package file should be
    * added to the generated .d.ts source
    */
-  private noAlias(): boolean {
-    return this.getArgument(ECliArgument.addAlias) === 'false'
+  private addAlias(): boolean {
+    return this.getArgument(ECliArgument.addAlias) !== 'false'
   }
 
   /**
@@ -670,8 +674,7 @@ export class Generator extends Cli {
    * generated .d.ts source
    * @param source generated .d.ts declaration source so far
    */
-  private addAlias(source: string) {
-    if (this.noAlias()) return source
+  private appendAlias(source: string) {
     verbose('Adding alias for main file of the package...')
 
     const packageDetails = this.getPackageDetails()
@@ -707,9 +710,7 @@ export class Generator extends Cli {
    * Append template where {0} is replaced with the name/path of the entry module.
    * @param source generated .d.ts declaration source so far
    */
-  private addTemplate(source: string) {
-    const tpl = this.getTemplate()
-    if (!tpl) return source
+  private appendTemplate(source: string) {
     verbose('Adding template')
 
     const entry = this.getEntry()
@@ -724,6 +725,7 @@ export class Generator extends Cli {
       noExistenceCheck: true,
     })
 
+    const tpl = this.getTemplate()
     const appliedTemplate = tpl.replace('{0}', mainFile)
 
     source += '\n' + appliedTemplate + '\n'

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -230,7 +230,7 @@ export class Generator extends Cli {
    * added to the generated .d.ts source
    */
   private noAlias(): boolean {
-    return this.getArgument(ECliArgument.noAlias) as boolean
+    return this.getArgument(ECliArgument.addAlias) === 'false'
   }
 
   /**

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -214,7 +214,7 @@ export class Generator extends Cli {
   }
 
   /**
-   * Append this template where {0} is replaced with the name/path of the entry module.
+   * Append this template where {main-module} is replaced with the name/path of the entry module.
    */
   private getTemplate(): string | undefined {
     return this.getArgument(ECliArgument.template) as string | undefined
@@ -698,7 +698,7 @@ export class Generator extends Cli {
   }
 
   /**
-   * Append template where {0} is replaced with the name/path of the entry module.
+   * Append template where {main-module} is replaced with the name/path of the entry module.
    * @param source generated .d.ts declaration source so far
    */
   private appendTemplate(source: string) {
@@ -717,7 +717,7 @@ export class Generator extends Cli {
     })
 
     const tpl = this.getTemplate()
-    const appliedTemplate = tpl.replace('{0}', mainFile)
+    const appliedTemplate = tpl.replace('{main-module}', mainFile)
 
     source += '\n' + appliedTemplate + '\n'
 

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -751,12 +751,6 @@ const shakeStrategies = {
     ]
     return refs.filter(match => match !== null).map(match => match[2])
   },
-
-  [EShakeOptions.exportedOnly]: (lines: string[]) => {
-    const exports = /export .*? from ['"]([^'"]+)['"]/
-    const refs = lines.map(l => l.match(exports))
-    return refs.filter(m => m !== null).map(m => m[1])
-  },
 }
 
 /**

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -553,7 +553,7 @@ export class Generator extends Cli {
   }
 
   private resolveImportSourcesAtFile(source: string, moduleName: string) {
-    let lines = this.sourceLines(source)
+    let lines = this.splitSourceToLines(source)
 
     lines = lines.map(line => {
       line = this.resolveImportSourcesAtLine(
@@ -576,7 +576,7 @@ export class Generator extends Cli {
     return source
   }
 
-  private sourceLines(source: string) {
+  private splitSourceToLines(source: string) {
     source = source.replace(/\r\n/g, '\n')
     source = source.replace(/\n\r/g, '\n')
     source = source.replace(/\r/g, '\n')
@@ -610,7 +610,7 @@ export class Generator extends Cli {
     }
     this.shakenModules.set(moduleName, fileSource)
 
-    const lines = this.sourceLines(fileSource)
+    const lines = this.splitSourceToLines(fileSource)
     const referencedModules = this.shakeStrategy(lines)
 
     verbose(`"${moduleName}" references ${JSON.stringify(referencedModules)}`)

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -244,11 +244,11 @@ export class Generator extends Cli {
    * Checks how and if tree-shaking should be applied
    */
   private getShake(): 'off' | 'exportOnly' | 'allImports' {
-    const shake = this.getArgument(ECliArgument.shake) as undefined | 'off' | 'exportOnly' | 'allImports';
-    if (shake === undefined) return 'off';
-    if (shake === 'exportOnly' || shake === 'allImports' || shake === 'off') return shake;
-    error(`Unknown value for shake "${shake}"`);
-    if (shake === undefined) return 'off';
+    const shake = this.getArgument(ECliArgument.shake) as undefined | 'off' | 'exportOnly' | 'allImports'
+    if (shake === undefined) return 'off'
+    if (shake === 'exportOnly' || shake === 'allImports' || shake === 'off') return shake
+    error(`Unknown value for shake "${shake}"`)
+    if (shake === undefined) return 'off'
   }
 
   /**
@@ -542,7 +542,7 @@ export class Generator extends Cli {
    * @param moduleName name of module containing import
    */
   private resolveImportSources(source: string, moduleName: string) {
-    let lines = this.sourceLines(source);
+    let lines = this.sourceLines(source)
 
     lines = lines.map(line => {
       line = this.resolveImportSourcesAtLine(
@@ -570,7 +570,7 @@ export class Generator extends Cli {
     source = source.replace(/\n\r/g, '\n')
     source = source.replace(/\r/g, '\n')
 
-    let lines = source.split('\n')
+    const lines = source.split('\n')
     return lines
   }
 
@@ -580,31 +580,31 @@ export class Generator extends Cli {
     shakenTypings: Set<string>,
     filter: 'exportOnly' | 'allImports'
   ): void {
-    shakenTypings.add(moduleName);
-    const current = typings[moduleName];
-    let lines = this.sourceLines(current);
-    const refs = filter === 'allImports' ? this.findAllImportedRefs(lines) : this.findExportedRefsOnly(lines);
+    shakenTypings.add(moduleName)
+    const current = typings[moduleName]
+    const lines = this.sourceLines(current)
+    const refs = filter === 'allImports' ? this.findAllImportedRefs(lines) : this.findExportedRefsOnly(lines)
     verbose(`"${moduleName}" references ${JSON.stringify(refs)}`)
 
     for (const ref of refs) {
-      this.findDependencies(typings, ref, shakenTypings, filter);
+      this.findDependencies(typings, ref, shakenTypings, filter)
     }
   }
 
   private findExportedRefsOnly(lines: string[]) {
     const exports = /export .*? from ['"]([^'"]+)['"]/
     const refs = lines.map(l => l.match(exports))
-    return refs.filter(m => m !== null).map(m => m[1]);;
+    return refs.filter(m => m !== null).map(m => m[1])
   }
 
   private findAllImportedRefs(lines: string[]) {
-    const staticImports = /(from ['"])([^'"]+)(['"])/;
-    const inlineImport = /(import\(['"])([^'"]+)(['"]\))/;
+    const staticImports = /(from ['"])([^'"]+)(['"])/
+    const inlineImport = /(import\(['"])([^'"]+)(['"]\))/
     const refs = [
       ...lines.map(l => l.match(staticImports)),
       ...lines.map(l => l.match(inlineImport))
     ]
-    return refs.filter(m => m !== null).map(m => m[1]);;
+    return refs.filter(m => m !== null).map(m => m[1])
   }
 
   /**
@@ -621,18 +621,18 @@ export class Generator extends Cli {
     Object.entries(typings).forEach(([moduleName, fileSource]) => {
       fileSource = fileSource.replace(/declare /g, '')
       fileSource = this.resolveImportSources(fileSource, moduleName)
-      typings[moduleName] = fileSource;
+      typings[moduleName] = fileSource
     })
 
     const mainFile = this.getMain()
-    const shake = this.getShake();
+    const shake = this.getShake()
 
     if (shake !== 'off') {
       verbose(`Shaking typeings using the ${shake} strategy.`)
-      const referenced = new Set<string>();
-      this.findDependencies(typings, mainFile, referenced, shake);
-      const shakenTypings = Object.fromEntries(Array.from(referenced).map(ref => [ref, typings[ref]]));
-      typings = shakenTypings;
+      const referenced = new Set<string>()
+      this.findDependencies(typings, mainFile, referenced, shake)
+      const shakenTypings = Object.fromEntries(Array.from(referenced).map(ref => [ref, typings[ref]]))
+      typings = shakenTypings
     }
 
     const sourceParts: string[] = []
@@ -663,7 +663,7 @@ export class Generator extends Cli {
    * @param source generated .d.ts declaration source so far
    */
   private addAlias(source: string) {
-    if (this.noAlias()) return source;
+    if (this.noAlias()) return source
     verbose('Adding alias for main file of the package...')
 
     const packageDetails = this.getPackageDetails()
@@ -696,12 +696,12 @@ export class Generator extends Cli {
   }
 
   /**
-  * Append template where {0} is replaced with the name/path of the entry module.
-  * @param source generated .d.ts declaration source so far
-  */
+   * Append template where {0} is replaced with the name/path of the entry module.
+   * @param source generated .d.ts declaration source so far
+   */
   private addTemplate(source: string) {
-    const tpl = this.getTemplate();
-    if (!tpl) return source;
+    const tpl = this.getTemplate()
+    if (!tpl) return source
     verbose('Adding template')
 
     const entry = this.getEntry()
@@ -716,7 +716,7 @@ export class Generator extends Cli {
       noExistenceCheck: true,
     })
 
-    const appliedTemplate = tpl.replace('{0}', mainFile);
+    const appliedTemplate = tpl.replace('{0}', mainFile)
 
     source += '\n' + appliedTemplate + '\n'
 

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -693,11 +693,14 @@ export class Generator extends Cli {
       throw new Error('No entry file is available!')
     }
 
-    const mainFile = this.convertPathToModule(resolve(this.getRoot(), entry), {
+    const mainModule = this.convertPathToModule(
+      resolve(this.getRoot(), entry),
+      {
       rootType: IBasePathType.root,
       noExistenceCheck: true,
-    })
-    return mainFile
+      },
+    )
+    return mainModule
   }
 
   /**
@@ -707,20 +710,10 @@ export class Generator extends Cli {
   private appendTemplate(source: string) {
     verbose('Adding template')
 
-    const entry = this.getEntry()
-
-    if (!entry) {
-      error('No entry file is available!')
-      throw new Error('No entry file is available!')
-    }
-
-    const mainFile = this.convertPathToModule(resolve(this.getRoot(), entry), {
-      rootType: IBasePathType.root,
-      noExistenceCheck: true,
-    })
-
+    const mainModule = this.getMainModule()
     const tpl = this.getTemplate()
-    const appliedTemplate = tpl.replace('{main-module}', mainFile)
+
+    const appliedTemplate = tpl.replace('{main-module}', mainModule)
 
     source += '\n' + appliedTemplate + '\n'
 

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -611,8 +611,8 @@ export class Generator extends Cli {
   }
 
   private findAllImportedRefs(lines: string[]) {
-    const staticImports = /(from ['"])([^'"]+)(['"])/
-    const inlineImport = /(import\(['"])([^'"]+)(['"]\))/
+    const staticImports = /from ['"]([^'"]+)['"]/
+    const inlineImport = /import\(['"]([^'"]+)['"]\)/
     const refs = [
       ...lines.map(l => l.match(staticImports)),
       ...lines.map(l => l.match(inlineImport)),

--- a/test/sources/default/otherIndex.ts
+++ b/test/sources/default/otherIndex.ts
@@ -1,0 +1,7 @@
+import {A} from './src/a'
+
+export * from './src/a'
+export * from './src/c'
+//export * from './src/a.schema'
+
+A.test(A.getText().value)

--- a/test/tests/e2e.test.ts
+++ b/test/tests/e2e.test.ts
@@ -30,8 +30,8 @@ describe('Default behavior', () => {
     'index.d.ts',
     'default',
   )
-  const shakeAllImports = getSource(
-    `--shake allImports`,
+  const shakeReferencedOnly = getSource(
+    `--shake referencedOnly`,
     'index.d.ts',
     'default',
   )
@@ -152,7 +152,7 @@ describe('Default behavior', () => {
 
   it('shake with the proper strategy', () => {
     expect(standard.includes('ASchema')).toBeTruthy()
-    expect(shakeAllImports.includes('ASchema')).toBeFalsy()
+    expect(shakeReferencedOnly.includes('ASchema')).toBeFalsy()
   })
 
   it('re-exports JS modules', () => {

--- a/test/tests/e2e.test.ts
+++ b/test/tests/e2e.test.ts
@@ -26,7 +26,7 @@ describe('Default behavior', () => {
     'default',
   )
   const customDtsSourceNoAliasTemplate = getSource(
-    `--template "declare const myMod: typeof import('{0}').default" --addAlias false`,
+    `--template "declare const myMod: typeof import('{main-module}').default" --addAlias false`,
     'index.d.ts',
     'default',
   )

--- a/test/tests/e2e.test.ts
+++ b/test/tests/e2e.test.ts
@@ -55,7 +55,7 @@ describe('Default behavior', () => {
     )
 
     exec(
-      `node "${scriptPath}" -m -r "${projectPath}" --addAlias false -c " -p tsconfig.test.json" -o ${customOutputNoAlias} generate`,
+      `node "${scriptPath}" -m -r "${projectPath}" --template "declare const myMod: typeof import('{0}').default" --addAlias false -c " -p tsconfig.test.json" -o ${customOutputNoAlias} generate`,
     )
 
     exec(
@@ -175,6 +175,14 @@ describe('Default behavior', () => {
     expect(source.includes('export = main;')).toBeTruthy()
     expect(customDtsSource.includes('export = main;')).toBeTruthy()
     expect(customDtsSourceNoAlias.includes('export = main;')).toBeFalsy()
+  })
+
+  it('insert templates', () => {
+    expect(
+      customDtsSourceNoAlias.includes(
+        "declare const myMod: typeof import('test-default/index').default",
+      ),
+    ).toBeTruthy()
   })
 
   it('re-exports JS modules', () => {

--- a/test/tests/e2e.test.ts
+++ b/test/tests/e2e.test.ts
@@ -26,7 +26,7 @@ describe('Default behavior', () => {
     'default',
   )
   const customDtsSourceNoAliasTemplate = getSource(
-    `--template "declare const myMod: typeof import('{main-module}').default" --addAlias false`,
+    `--template "declare const myMod: typeof import('{main-module}')" --addAlias false`,
     'index.d.ts',
     'default',
   )
@@ -145,7 +145,7 @@ describe('Default behavior', () => {
   it('insert templates', () => {
     expect(
       customDtsSourceNoAliasTemplate.includes(
-        "declare const myMod: typeof import('test-default/index').default",
+        "declare const myMod: typeof import('test-default/index')",
       ),
     ).toBeTruthy()
   })


### PR DESCRIPTION
Hi,

I have a huge and messy code base. I created a more or less isolated module, which I want to generate type definitions for.

`--shake`: I added basic tree-shaking support, so only the modules that are dependencies of my module are added.

`--noAlias`: I don't need the package alias in the generated .d.ts file, therefore I added a flag to remove it.

The module is exported to a namespace on the window object. With the `--template` option I can write something like this:

```cmd
npm-dts --template "interface Window {scripting: Scripting} interface Scripting {myApi: typeof import('{0}')}" generate
```
and I get something like this
```typescript
//... module declarations
interface Window {scripting: Scripting} interface Scripting {myApi: typeof import('myPackage/src/APIs/myAPI/index')}
```

If some of the three suggestions don't fit npm-dts I created branches for each of the features, so it's easy to exclude one of them.