### PR TITLE
Bump Typescript from 4.7.4 to 4.9.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "ts-node": "10.8.1",
         "tslint": "6.1.3",
         "typedoc": "0.22.17",
-        "typescript": "4.7.4",
+        "typescript": "^4.8.4",
         "webpack": "5.73.0",
         "webpack-cli": "4.10.0",
         "webpack-node-externals": "3.0.0"
@@ -6361,9 +6361,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -11577,9 +11577,9 @@
       }
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
     "update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-dts",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "description": "Simple DTS single-file generation utility for TypeScript bundles",
   "main": "dist/index.js",
   "bin": {
@@ -67,7 +67,7 @@
     "ts-node": "10.8.1",
     "tslint": "6.1.3",
     "typedoc": "0.22.17",
-    "typescript": "4.7.4",
+    "typescript": "^4.8.4",
     "webpack": "5.73.0",
     "webpack-cli": "4.10.0",
     "webpack-node-externals": "3.0.0"


### PR DESCRIPTION
Bumping to the latest Typescript 4 version could allow us to enjoy bugfixes without having a breaking change.

For example, when using npm-dts-webpack-plugin, I currently get the following error: `error TS2694: Namespace 'Intl' has no exported member 'LocalesArgument'.`
The solution to this error is to upgrade to version 4.8.4 or higher.